### PR TITLE
Fix: Spawn server instance on client start

### DIFF
--- a/backend/client/run/run.go
+++ b/backend/client/run/run.go
@@ -3,5 +3,6 @@ package main
 import "github.com/gsarmaonline/goiter/client"
 
 func main() {
+	go client.StartServer() // Start the server in a new goroutine
 	client.Run()
 }

--- a/backend/client/server.go
+++ b/backend/client/server.go
@@ -3,6 +3,7 @@ package client
 import (
 	"log"
 	"os"
+	"fmt" // Added for printing
 
 	"github.com/gsarmaonline/goiter/config"
 	"github.com/gsarmaonline/goiter/core"
@@ -10,6 +11,7 @@ import (
 )
 
 func StartServer() {
+	fmt.Println("Attempting to start server...") // Added print statement
 	// Try to load .env file, but don't fail if it doesn't exist
 	if err := godotenv.Load(); err != nil {
 		log.Printf("Warning: .env file not found or error loading it: %v", err)


### PR DESCRIPTION
- Modified backend/client/run/run.go to call client.StartServer() in a goroutine.
- This ensures the server starts in the background when the client runs.
- Added a debug print statement to client.StartServer() to help verify it's being called.